### PR TITLE
Add test for IPL CSV columns

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,8 @@
+import pandas as pd
+from pathlib import Path
+
+def test_ipl_csv_columns():
+    csv_path = Path(__file__).resolve().parents[1] / 'data' / 'ipl-2025-mumbai-indians-UTC.csv'
+    df = pd.read_csv(csv_path)
+    expected_columns = ['Match Number','Round Number','Date','Location','Home Team','Away Team','Result']
+    assert list(df.columns) == expected_columns


### PR DESCRIPTION
## Summary
- add pytest test for loading IPL schedule data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68464e150b4c83208e02b799080db998